### PR TITLE
chore: Migrate from pep517 to python-build

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -21,20 +21,16 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.8
-    - name: Install pep517, check-manifest, and twine
+    - name: Install python-build, check-manifest, and twine
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install pep517 --user
-        python -m pip install check-manifest twine
+        python -m pip install build check-manifest twine
     - name: Check MANIFEST
       run: |
         check-manifest
-    - name: Test the build backend is compliant with PEP517
-      run: |
-        python -m pep517.check .
     - name: Build a wheel and a sdist
       run: |
-        python -m pep517.build --source --binary --out-dir dist/ .
+        python -m build --sdist --wheel --outdir dist/ .
     - name: Verify untagged commits have dev versions
       if: "!startsWith(github.ref, 'refs/tags/')"
       run: |

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -40,25 +40,25 @@ jobs:
         wheel_name=$(find dist/ -iname "*.whl" -printf "%f\n")
         if [[ "${latest_tag_revlist_SHA}" != "${master_SHA}" ]]; then # don't check master push events coming from tags
           if [[ "${wheel_name}" == *"pandamonium-0.1.dev"* || "${wheel_name}" != *"dev"* ]]; then
-            echo "pep517.build incorrectly named built distribution: ${wheel_name}"
-            echo "pep517 is lacking the history and tags required to determine version number"
+            echo "python-build incorrectly named built distribution: ${wheel_name}"
+            echo "python-build is lacking the history and tags required to determine version number"
             echo "intentionally erroring with 'return 1' now"
             return 1
           fi
         else
           echo "Push event to origin/master was triggered by push of tag ${latest_tag}"
         fi
-        echo "pep517.build named built distribution: ${wheel_name}"
+        echo "python-build named built distribution: ${wheel_name}"
     - name: Verify tagged commits don't have dev versions
       if: startsWith(github.ref, 'refs/tags')
       run: |
         wheel_name=$(find dist/ -iname "*.whl" -printf "%f\n")
         if [[ "${wheel_name}" == *"dev"* ]]; then
-          echo "pep517.build incorrectly named built distribution: ${wheel_name}"
+          echo "python-build incorrectly named built distribution: ${wheel_name}"
           echo "this is incorrrectly being treated as a dev release"
           echo "intentionally erroring with 'return 1' now"
           return 1
         fi
-        echo "pep517.build named built distribution: ${wheel_name}"
+        echo "python-build named built distribution: ${wheel_name}"
     - name: Verify the distribution
       run: twine check dist/*


### PR DESCRIPTION
Switch from using the now deprecated [`pep517`](https://github.com/pypa/pep517/) to build sdist and wheels to the new [`python-build`](https://github.com/FFY00/python-build) library. c.f. https://github.com/scikit-hep/pyhf/pull/1066 for more context.

(I forgot to migrate this over into PR #29 once we learned about this for `pyhf`).

**Suggested squash and merge commit message**

```
* Migrate from the deprecated pep517.build to python-build CLI for builds for packaging
   - c.f. https://github.com/pypa/pep517/pull/83
* Remove check stage as done implicitly with python-build
```