### PR TITLE
ci: Add distribution to TestPyPI

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -62,3 +62,10 @@ jobs:
         echo "python-build named built distribution: ${wheel_name}"
     - name: Verify the distribution
       run: twine check dist/*
+    - name: Publish distribution 📦 to Test PyPI
+      # every PR will trigger a push event on master, so check the push event is actually coming from master
+      if: github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'dguest/pandamonium'
+      uses: pypa/gh-action-pypi-publish@v1.3.1
+      with:
+        password: ${{ secrets.test_pypi_password }}
+        repository_url: https://test.pypi.org/legacy/

--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ This tells you if your jobs are done. And stuff like that.
 
 ## Installation
 
-### Install from PyPI
+### Install from TestPyPI
 
-You can install [`pandamonium` from PyPI][pandamonium_PyPI] into any Python
+You can install [`pandamonium` from TestPyPI][pandamonium_TestPyPI] into any Python
 virtual environment by simply running
 
 ```
-python -m pip install pandamonium
+python -m pip install --extra-index-url https://test.pypi.org/simple/ --pre pandamonium
 ```
 
 ### Install the old style of global scripts
@@ -44,6 +44,7 @@ if [ -d "your/path/stuff/goes/here/pandamonium" ]; then
 fi
 ```
 
+[pandamonium_TestPyPI]: https://test.pypi.org/project/pandamonium/
 [pandamonium_PyPI]: https://pypi.org/project/pandamonium/
 [tag_v0.1]: https://github.com/dguest/pandamonium/releases/tag/v0.1
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ You can install [`pandamonium` from TestPyPI][pandamonium_TestPyPI] into any Pyt
 virtual environment by simply running
 
 ```
-python -m pip install --extra-index-url https://test.pypi.org/simple/ --pre pandamonium
+python -m pip install panda-client # Needed as panda-client isn't on TestPyPI
+python -m pip install -i https://test.pypi.org/simple/ --pre pandamonium
 ```
 
 ### Install the old style of global scripts


### PR DESCRIPTION
Use the https://github.com/pypa/gh-action-pypi-publish to publish to TestPyPI every time a PR is merged.

**Suggested squash and merge commit message**

```
* Add publishing to TestPyPI on PR merge using the PyPA publishing GitHub Action
   - c.f. https://github.com/pypa/gh-action-pypi-publish
* Direct users to use TestPyPI install until PyPI namespace is acquired
```