### PR TITLE
docs: Add PyPI to install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This tells you if your jobs are done. And stuff like that.
 ### Install from PyPI
 
 You can install [`pandamonium` from PyPI][pandamonium_PyPI] into any Python
-virtual environment by simply running
+virtual environment by running
 
 ```
 python -m pip install pandamonium
@@ -51,7 +51,7 @@ fi
 
 You can install the latest development release of
 [`pandamonium` from TestPyPI][pandamonium_TestPyPI] into any Python virtual
-environment by simply running
+environment by running
 
 ```
 python -m pip install --extra-index-url https://test.pypi.org/simple/ --pre pandamonium

--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ virtual environment by simply running
 python -m pip install --extra-index-url https://test.pypi.org/simple/ --pre pandamonium
 ```
 
+> **Note:** This adds TestPyPI as [an additional package index to search][additional_package_index]
+when installing `pandamonium` specifically.
+PyPI will still be the default package index `pip` will attempt to install from
+for all dependencies.
+
 ### Install the old style of global scripts
 
 If you want to install the original version of `pandamonium` before it became a
@@ -48,6 +53,7 @@ fi
 ```
 
 [pandamonium_TestPyPI]: https://test.pypi.org/project/pandamonium/
+[additional_package_index]: https://pip.pypa.io/en/stable/reference/pip_install/#cmdoption-extra-index-url
 [pandamonium_PyPI]: https://pypi.org/project/pandamonium/
 [tag_v0.1]: https://github.com/dguest/pandamonium/releases/tag/v0.1
 

--- a/README.md
+++ b/README.md
@@ -47,60 +47,8 @@ if [ -d "your/path/stuff/goes/here/pandamonium" ]; then
 fi
 ```
 
-### Install from TestPyPI
-
-You can install the latest development release of
-[`pandamonium` from TestPyPI][pandamonium_TestPyPI] into any Python virtual
-environment by running
-
-```
-python -m pip install --extra-index-url https://test.pypi.org/simple/ --pre pandamonium
-```
-
-> **Note:** This adds TestPyPI as [an additional package index to search][additional_package_index]
-when installing `pandamonium` specifically.
-PyPI will still be the default package index `pip` will attempt to install from
-for all dependencies.
-
-[pandamonium_TestPyPI]: https://test.pypi.org/project/pandamonium/
-[additional_package_index]: https://pip.pypa.io/en/stable/reference/pip_install/#cmdoption-extra-index-url
 [pandamonium_PyPI]: https://pypi.org/project/pandamonium/
 [tag_v0.1]: https://github.com/dguest/pandamonium/releases/tag/v0.1
-
-### Notes if working on a remote server
-
-If you are working from a remote server where you do not have control over your
-Python runtimes (e.g. LXPLUS, ALTAS Connect login nodes) it is recommended that
-you bootstrap `virtualenv` and a default Python virtual environment by adding
-the following to your `.bashrc` or `.bashrc_user`
-
-```
-# Ensure local virtualenv setup
-if [ ! -f "${HOME}/opt/venv/bin/virtualenv" ]; then
-    curl -sL --location --output /tmp/virtualenv.pyz https://bootstrap.pypa.io/virtualenv.pyz
-    python /tmp/virtualenv.pyz ~/opt/venv # Change this to python3 if available
-    ~/opt/venv/bin/pip install --upgrade pip
-    ~/opt/venv/bin/pip install virtualenv
-    mkdir -p ~/bin  # Ensure exists if new machine
-    ln -s ~/opt/venv/bin/virtualenv ~/bin/virtualenv
-fi
-
-# default venv from `virtualenv "${HOME}/.venvs/base"`
-if [ -d "${HOME}/.venvs/base" ]; then
-    source "${HOME}/.venvs/base/bin/activate"
-fi
-```
-
-After that source your `.profile` or `.bash_profile` and then if you want to
-create a default Python virtual environment run
-
-```
-virtualenv "${HOME}/.venvs/base"
-```
-
-You will now be dropped into a virtual environment named `base` each time you login.
-The virtual environment is not special in anyway, so you should treat it as you
-would any other.
 
 ## Use
 
@@ -181,6 +129,61 @@ pandamon your.tasks -m
 See [this JIRA ticket][1] where they plan to make it faster.
 
 [1]: https://its.cern.ch/jira/browse/ATLASPANDA-492
+
+## Additional Technical Information
+
+### Install development release from TestPyPI
+
+You can install the latest development release of
+[`pandamonium` from TestPyPI][pandamonium_TestPyPI] into any Python virtual
+environment by running
+
+```
+python -m pip install --extra-index-url https://test.pypi.org/simple/ --pre pandamonium
+```
+
+> **Note:** This adds TestPyPI as [an additional package index to search][additional_package_index]
+when installing `pandamonium` specifically.
+PyPI will still be the default package index `pip` will attempt to install from
+for all dependencies.
+
+[pandamonium_TestPyPI]: https://test.pypi.org/project/pandamonium/
+[additional_package_index]: https://pip.pypa.io/en/stable/reference/pip_install/#cmdoption-extra-index-url
+
+### Notes if working on a remote server
+
+If you are working from a remote server where you do not have control over your
+Python runtimes (e.g. LXPLUS, ALTAS Connect login nodes) it is recommended that
+you bootstrap `virtualenv` and a default Python virtual environment by adding
+the following to your `.bashrc` or `.bashrc_user`
+
+```
+# Ensure local virtualenv setup
+if [ ! -f "${HOME}/opt/venv/bin/virtualenv" ]; then
+    curl -sL --location --output /tmp/virtualenv.pyz https://bootstrap.pypa.io/virtualenv.pyz
+    python /tmp/virtualenv.pyz ~/opt/venv # Change this to python3 if available
+    ~/opt/venv/bin/pip install --upgrade pip
+    ~/opt/venv/bin/pip install virtualenv
+    mkdir -p ~/bin  # Ensure exists if new machine
+    ln -s ~/opt/venv/bin/virtualenv ~/bin/virtualenv
+fi
+
+# default venv from `virtualenv "${HOME}/.venvs/base"`
+if [ -d "${HOME}/.venvs/base" ]; then
+    source "${HOME}/.venvs/base/bin/activate"
+fi
+```
+
+After that source your `.profile` or `.bash_profile` and then if you want to
+create a default Python virtual environment run
+
+```
+virtualenv "${HOME}/.venvs/base"
+```
+
+You will now be dropped into a virtual environment named `base` each time you login.
+The virtual environment is not special in anyway, so you should treat it as you
+would any other.
 
 ## Testimonials
 

--- a/README.md
+++ b/README.md
@@ -18,19 +18,14 @@ This tells you if your jobs are done. And stuff like that.
 
 ## Installation
 
-### Install from TestPyPI
+### Install from PyPI
 
-You can install [`pandamonium` from TestPyPI][pandamonium_TestPyPI] into any Python
+You can install [`pandamonium` from PyPI][pandamonium_PyPI] into any Python
 virtual environment by simply running
 
 ```
-python -m pip install --extra-index-url https://test.pypi.org/simple/ --pre pandamonium
+python -m pip install pandamonium
 ```
-
-> **Note:** This adds TestPyPI as [an additional package index to search][additional_package_index]
-when installing `pandamonium` specifically.
-PyPI will still be the default package index `pip` will attempt to install from
-for all dependencies.
 
 ### Install the old style of global scripts
 
@@ -51,6 +46,21 @@ if [ -d "your/path/stuff/goes/here/pandamonium" ]; then
     export PATH
 fi
 ```
+
+### Install from TestPyPI
+
+You can install the latest development release of
+[`pandamonium` from TestPyPI][pandamonium_TestPyPI] into any Python virtual
+environment by simply running
+
+```
+python -m pip install --extra-index-url https://test.pypi.org/simple/ --pre pandamonium
+```
+
+> **Note:** This adds TestPyPI as [an additional package index to search][additional_package_index]
+when installing `pandamonium` specifically.
+PyPI will still be the default package index `pip` will attempt to install from
+for all dependencies.
 
 [pandamonium_TestPyPI]: https://test.pypi.org/project/pandamonium/
 [additional_package_index]: https://pip.pypa.io/en/stable/reference/pip_install/#cmdoption-extra-index-url

--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ You can install [`pandamonium` from TestPyPI][pandamonium_TestPyPI] into any Pyt
 virtual environment by simply running
 
 ```
-python -m pip install panda-client # Needed as panda-client isn't on TestPyPI
-python -m pip install -i https://test.pypi.org/simple/ --pre pandamonium
+python -m pip install --extra-index-url https://test.pypi.org/simple/ --pre pandamonium
 ```
 
 ### Install the old style of global scripts


### PR DESCRIPTION
Add installation from PyPI as the first listed installation method:

```
python -m pip install pandamonium
```

Additionally, still keep the TestPyPI instructions but note they are for dev releases and recommend that users use `--extra-index-url` as the installation method for installing from TestPyPI as this adds TestPyPI as [an additional package index to search](https://pip.pypa.io/en/stable/reference/pip_install/#cmdoption-extra-index-url) when installing `pandamonium` specifically. PyPI will still be the default package index `pip` will attempt to install from for all dependencies.

This didn't work when `pandamonium` on PyPI was not under our control, and so 

```
python -m pip install -i https://test.pypi.org/simple/ --pre pandamonium
```

was required after first installing `panda-client`. This is no no longer needed.

```
$ docker run --rm -it python:3.8 /bin/bash
root@7adbb34fd641:/# python -m pip install -q --extra-index-url https://test.pypi.org/simple/ --pre pandamonium
root@7adbb34fd641:/# python -m pip list
Package      Version
------------ --------
panda-client 1.4.36
pandamonium  0.2.dev3
pip          20.2.3
setuptools   50.3.0
wheel        0.35.1
```

**Suggested squash and merge commit message:**

```
* Add PyPI as the primary suggested installation method
* Add section on Additional Technical Information
* Add instructions on installing test releases from TestPyPI using --extra-index-url and --pre
   - c.f. https://pip.pypa.io/en/stable/reference/pip_install/#cmdoption-extra-index-url
   - Note that TestPyPI is for development releases
```