### PR TITLE
docs: Add PyPI info badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Pandamonium
 [![GitHub Project](https://img.shields.io/badge/GitHub--blue?style=social&logo=GitHub)](https://github.com/dguest/pandamonium)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4019463.svg)](https://doi.org/10.5281/zenodo.4019463)
 
+[![PyPI version](https://badge.fury.io/py/pandamonium.svg)](https://badge.fury.io/py/pandamonium)
+
 Cause panda and rucio don't work too good
 
 This tells you if your jobs are done. And stuff like that.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Pandamonium
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4019463.svg)](https://doi.org/10.5281/zenodo.4019463)
 
 [![PyPI version](https://badge.fury.io/py/pandamonium.svg)](https://badge.fury.io/py/pandamonium)
+[![Supported Python versions](https://img.shields.io/pypi/pyversions/pandamonium.svg)](https://pypi.org/project/pandamonium/)
 
 Cause panda and rucio don't work too good
 


### PR DESCRIPTION
Add badges to README that add information on the current PyPI release version as well as the versions of Python that are supported for the PyPI release.

- [![PyPI version](https://badge.fury.io/py/pandamonium.svg)](https://badge.fury.io/py/pandamonium)
- [![Supported Python versions](https://img.shields.io/pypi/pyversions/pandamonium.svg)](https://pypi.org/project/pandamonium/)

**Suggested squash and merge commit message**

```
* Add badges for PyPI release version and supported Python versions to README
```