### PR TITLE
chore: Migrate from bumpversion to bump2version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ extras_require["develop"] = sorted(
     set(
         extras_require["test"]
         + extras_require["lint"]
-        + ["check-manifest", "bump2version", "pre-commit", "twine"]
+        + ["check-manifest", "bump2version~=1.0", "pre-commit", "twine"]
     )
 )
 extras_require["complete"] = sorted(set(sum(extras_require.values(), [])))

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ extras_require["develop"] = sorted(
     set(
         extras_require["test"]
         + extras_require["lint"]
-        + ["check-manifest", "bumpversion~=0.5", "pre-commit", "twine"]
+        + ["check-manifest", "bump2version", "pre-commit", "twine"]
     )
 )
 extras_require["complete"] = sorted(set(sum(extras_require.values(), [])))


### PR DESCRIPTION
@dguest has brought to my attention that [`bumpversion` is no longer maintained](https://github.com/peritus/bumpversion) (as of apparently November 2019). Given this we should probably take the project's advice

> 🎬 If you want to start using `bumpversion`, you're best advised to install one of the maintained forks, e.g. ➡ @ c4urself's [`bump2version`](https://github.com/c4urself/bump2version/#installation).

This PR migrates to using `bump2version` `v1.X` release series.

**Suggested squash and merge commit message:**

```
* Migrate from using bumpversion to bump2version in the develop extra
   - bumpversion is no longer maintained and bump2version is the recommended fork
   - Use bump2version v1.X series
```