### PR TITLE
feat: Apply isort

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# text editor settings
+.vscode/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,4 +3,7 @@ repos:
     rev: 20.8b1
     hooks:
     - id: black
-      language_version: python3
+-   repo: https://github.com/pycqa/isort
+    rev: 5.7.0
+    hooks:
+    - id: isort

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,3 +26,6 @@ ignore = [
     'panda-resub-taskid',
     'panda-shortname'
 ]
+
+[tool.isort]
+force_single_line = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,4 +28,6 @@ ignore = [
 ]
 
 [tool.isort]
+profile = "black"
+multi_line_output = 3
 force_single_line = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,3 +31,6 @@ ignore = [
 profile = "black"
 multi_line_output = 3
 force_single_line = true
+ignore_comments = true
+float_to_top = true
+skip = ["src/pandamonium/version.py"]

--- a/src/pandamonium/cli/cli.py
+++ b/src/pandamonium/cli/cli.py
@@ -1,5 +1,5 @@
-import logging
 import argparse
+import logging
 
 from ..version import __version__
 

--- a/src/pandamonium/panda_kill_taskid.py
+++ b/src/pandamonium/panda_kill_taskid.py
@@ -6,10 +6,6 @@ Kill jobs with pbook
 Runs on pure python beauty.
 """
 
-_h_jobid = 'panda taskid, you can also pipe them'
-
-epi = 'Thanks ATLAS. Thatlas.'
-
 import argparse
 import sys
 
@@ -18,6 +14,10 @@ try:
 except ImportError:
     print("Failed to load PandaClient, please set up locally")
     sys.exit(1)
+
+_h_jobid = 'panda taskid, you can also pipe them'
+
+epi = 'Thanks ATLAS. Thatlas.'
 
 
 def get_args():

--- a/src/pandamonium/panda_kill_taskid.py
+++ b/src/pandamonium/panda_kill_taskid.py
@@ -10,8 +10,8 @@ _h_jobid = 'panda taskid, you can also pipe them'
 
 epi = 'Thanks ATLAS. Thatlas.'
 
-import sys
 import argparse
+import sys
 
 try:
     from pandatools import PBookCore

--- a/src/pandamonium/panda_resub_taskid.py
+++ b/src/pandamonium/panda_resub_taskid.py
@@ -11,8 +11,8 @@ _h_kill = 'kill any running jobs before retrying them'
 
 epi = 'Thanks ATLAS. Thatlas.'
 
-import sys
 import argparse
+import sys
 
 try:
     from pandatools import PBookCore

--- a/src/pandamonium/panda_resub_taskid.py
+++ b/src/pandamonium/panda_resub_taskid.py
@@ -6,11 +6,6 @@ Resubmit jobs with pbook
 Runs on pure python beauty.
 """
 
-_h_jobid = 'panda taskid, you can also pipe them'
-_h_kill = 'kill any running jobs before retrying them'
-
-epi = 'Thanks ATLAS. Thatlas.'
-
 import argparse
 import sys
 
@@ -19,6 +14,11 @@ try:
 except ImportError:
     print("Failed to load PandaClient, please set up locally")
     sys.exit(1)
+
+_h_jobid = 'panda taskid, you can also pipe them'
+_h_kill = 'kill any running jobs before retrying them'
+
+epi = 'Thanks ATLAS. Thatlas.'
 
 
 def get_args():

--- a/src/pandamonium/panda_shortname.py
+++ b/src/pandamonium/panda_shortname.py
@@ -8,13 +8,13 @@ remove any fields. Except the "scope", which seems totally
 worthless...
 """
 
-_help_remove = "remove fields that we usually don't care about"
-_help_prefix = "prefix file names with this"
-
 import argparse
 import os
 import re
 import sys
+
+_help_remove = "remove fields that we usually don't care about"
+_help_prefix = "prefix file names with this"
 
 
 def get_args():

--- a/src/pandamonium/panda_shortname.py
+++ b/src/pandamonium/panda_shortname.py
@@ -12,9 +12,9 @@ _help_remove = "remove fields that we usually don't care about"
 _help_prefix = "prefix file names with this"
 
 import argparse
+import os
 import re
 import sys
-import os
 
 
 def get_args():

--- a/src/pandamonium/pandamon.py
+++ b/src/pandamonium/pandamon.py
@@ -40,19 +40,20 @@ _def_stream = 'OUT'
 
 # Attempt to default to Python 3
 try:
-    from urllib.request import urlopen
-    from urllib.request import Request
     from urllib.parse import urlencode
+    from urllib.request import Request
+    from urllib.request import urlopen
 except:
     from urllib2 import urlopen
     from urllib2 import Request
     from urllib import urlencode
 
-import json
-import sys, os
-import re
 import argparse
 import datetime
+import json
+import os
+import re
+import sys
 
 _headers = {'Accept': 'application/json', 'Content-Type': 'application/json'}
 

--- a/src/pandamonium/pandamon.py
+++ b/src/pandamonium/pandamon.py
@@ -11,6 +11,23 @@ The user name can be specified via environment variable to reduce
 clutter.
 """
 
+# Attempt to default to Python 3
+try:
+    from urllib.parse import urlencode
+    from urllib.request import Request
+    from urllib.request import urlopen
+except:
+    from urllib2 import urlopen
+    from urllib2 import Request
+    from urllib import urlencode
+
+import argparse
+import datetime
+import json
+import os
+import re
+import sys
+
 # help strings
 _h_taskname = 'initial search string'
 _h_user = 'full user name, or blank for all'
@@ -37,23 +54,6 @@ _h_more_info_string = (
 # defaults
 _def_user = 'GRID_USER_NAME'
 _def_stream = 'OUT'
-
-# Attempt to default to Python 3
-try:
-    from urllib.parse import urlencode
-    from urllib.request import Request
-    from urllib.request import urlopen
-except:
-    from urllib2 import urlopen
-    from urllib2 import Request
-    from urllib import urlencode
-
-import argparse
-import datetime
-import json
-import os
-import re
-import sys
 
 _headers = {'Accept': 'application/json', 'Content-Type': 'application/json'}
 

--- a/src/pandamonium/pandamon.py
+++ b/src/pandamonium/pandamon.py
@@ -11,22 +11,23 @@ The user name can be specified via environment variable to reduce
 clutter.
 """
 
-# Attempt to default to Python 3
-try:
-    from urllib.parse import urlencode
-    from urllib.request import Request
-    from urllib.request import urlopen
-except:
-    from urllib2 import urlopen
-    from urllib2 import Request
-    from urllib import urlencode
-
 import argparse
 import datetime
 import json
 import os
 import re
 import sys
+
+# Attempt to default to Python 3
+try:
+    from urllib.parse import urlencode
+    from urllib.request import Request
+    from urllib.request import urlopen
+except:
+    from urllib import urlencode
+
+    from urllib2 import Request
+    from urllib2 import urlopen
 
 # help strings
 _h_taskname = 'initial search string'


### PR DESCRIPTION
Resolves #7 

Address the points of Issue #7 and automatically make sure this issue does not come up again in the future by using [`isort`](https://pycqa.github.io/isort/) to sort imports and force them to the top of their Python files.

**Suggested squash and merge commit message:**
```
* Add isort to pre-commit hooks
   - Add isort config options to pyproject.toml
* Apply isort to all Python files
   - Alphabetically sort imports with one import per line
* Move all imports to the top of Python files
* Add VS Code workspace setting to gitignore
```