### PR TITLE
ci: Add isort to linting workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,3 +27,6 @@ jobs:
     - name: Lint with Black
       run: |
         black --check --diff --verbose .
+    - name: Lint with isort
+      run: |
+        isort --check --diff --verbose .

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Like badges? We have the best badges:
 
 [![PyPI version](https://badge.fury.io/py/pandamonium.svg)](https://badge.fury.io/py/pandamonium)
 [![Supported Python versions](https://img.shields.io/pypi/pyversions/pandamonium.svg)](https://pypi.org/project/pandamonium/)
+
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/dguest/pandamonium/master.svg)](https://results.pre-commit.ci/latest/github/dguest/pandamonium/master)
 
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Like badges? We have the best badges:
 
 [![PyPI version](https://badge.fury.io/py/pandamonium.svg)](https://badge.fury.io/py/pandamonium)
 [![Supported Python versions](https://img.shields.io/pypi/pyversions/pandamonium.svg)](https://pypi.org/project/pandamonium/)
+[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/dguest/pandamonium/master.svg)](https://results.pre-commit.ci/latest/github/dguest/pandamonium/master)
 
 
 Installation

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 extras_require = {}
-extras_require["lint"] = sorted(set(["pyflakes", "black"]))
+extras_require["lint"] = sorted(set(["pyflakes", "black", "isort~=5.7"]))
 extras_require["test"] = sorted(
     set(
         [


### PR DESCRIPTION
Resolves #53 

Add `isort` to the linting workflow in CI and add `isort` to the `lint` extra.

**Suggested squash and merge commit message:**

```
* Add isort to 'lint' extra
* Add isort to linting GHA workflow
* Add pre-commit.ci status badge to README
```