### PR TITLE
fix: Update API to use panda-client v1.4.82 pandaclient API

### DIFF
--- a/src/pandamonium/panda_kill_taskid.py
+++ b/src/pandamonium/panda_kill_taskid.py
@@ -10,10 +10,13 @@ import argparse
 import sys
 
 try:
-    from pandatools import PBookCore
+    from pandaclient import PBookCore
 except ImportError:
-    print("Failed to load PandaClient, please set up locally")
-    sys.exit(1)
+    try:
+        from pandatools import PBookCore
+    except ImportError:
+        print("Failed to load PandaClient, please set up locally")
+        sys.exit(1)
 
 _h_jobid = 'panda taskid, you can also pipe them'
 

--- a/src/pandamonium/panda_resub_taskid.py
+++ b/src/pandamonium/panda_resub_taskid.py
@@ -10,10 +10,13 @@ import argparse
 import sys
 
 try:
-    from pandatools import PBookCore
+    from pandaclient import PBookCore
 except ImportError:
-    print("Failed to load PandaClient, please set up locally")
-    sys.exit(1)
+    try:
+        from pandatools import PBookCore
+    except ImportError:
+        print("Failed to load PandaClient, please set up locally")
+        sys.exit(1)
 
 _h_jobid = 'panda taskid, you can also pipe them'
 _h_kill = 'kill any running jobs before retrying them'


### PR DESCRIPTION
Resolves dguest/pandamonium#57 .  `pandatools` is renamed to `pandaclient`.

This will need a patch release to handle the API changes of the underlying tool.

```
* Adopt panda-client v1.4.82 `pandaclient` API
   - c.f. https://github.com/PanDAWMS/panda-client/commit/eee3914e78347a427ae80a2588d181a6b8632dfb
```
