### PR TITLE
fix: Update API to use panda-client v1.4.82 `pandaclient` API

### DIFF
--- a/src/pandamonium/panda_kill_taskid.py
+++ b/src/pandamonium/panda_kill_taskid.py
@@ -10,7 +10,7 @@ import argparse
 import sys
 
 try:
-    from pandatools import PBookCore
+    from pandaclient import PBookCore
 except ImportError:
     print("Failed to load PandaClient, please set up locally")
     sys.exit(1)

--- a/src/pandamonium/panda_resub_taskid.py
+++ b/src/pandamonium/panda_resub_taskid.py
@@ -10,7 +10,7 @@ import argparse
 import sys
 
 try:
-    from pandatools import PBookCore
+    from pandaclient import PBookCore
 except ImportError:
     print("Failed to load PandaClient, please set up locally")
     sys.exit(1)


### PR DESCRIPTION
Resolves #57

In https://github.com/PanDAWMS/panda-client/commit/eee3914e78347a427ae80a2588d181a6b8632dfb release `v1.4.82` the `panda-client` API was updated from `pandatools` to `pandaclient`. This PR applies that API change.

**Suggested squash and merge message**:
```
* Adopt panda-client v1.4.82 `pandaclient` API
   - c.f. https://github.com/PanDAWMS/panda-client/commit/eee3914e78347a427ae80a2588d181a6b8632dfb
```