### PR TITLE
ci: Update pre-commit and CI to latest releases and APIs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,21 +12,26 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+
     - name: Set up Python 3.9
       uses: actions/setup-python@v2
       with:
         python-version: 3.9
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install --upgrade --quiet --no-cache-dir --editable .[lint]
         python -m pip list
+
     - name: Lint with Pyflakes
       run: |
         python -m pyflakes .
+
     - name: Lint with Black
       run: |
         black --check --diff --verbose .
+
     - name: Lint with isort
       run: |
         isort --check --diff --verbose .

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -51,6 +51,9 @@ jobs:
     - name: Verify the distribution
       run: twine check dist/*
 
+    - name: List contents of sdist
+      run: tar --list --file dist/pandamonium-*.tar.gz
+
     - name: Publish distribution 📦 to Test PyPI
       # every PR will trigger a push event on master, so check the push event is actually coming from master
       if: github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'dguest/pandamonium'

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -18,20 +18,25 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
+
     - name: Set up Python 3.9
       uses: actions/setup-python@v2
       with:
         python-version: 3.9
+
     - name: Install python-build, check-manifest, and twine
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install build check-manifest twine
+
     - name: Check MANIFEST
       run: |
         check-manifest
+
     - name: Build a wheel and a sdist
       run: |
         python -m build --sdist --wheel --outdir dist/ .
+
     - name: Verify history available for dev versions
       run: |
         wheel_name=$(find dist/ -iname "*.whl" -printf "%f\n")
@@ -42,8 +47,10 @@ jobs:
           return 1
         fi
         echo "python-build named built distribution: ${wheel_name}"
+
     - name: Verify the distribution
       run: twine check dist/*
+
     - name: Publish distribution 📦 to Test PyPI
       # every PR will trigger a push event on master, so check the push event is actually coming from master
       if: github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'dguest/pandamonium'
@@ -51,6 +58,7 @@ jobs:
       with:
         password: ${{ secrets.test_pypi_password }}
         repository_url: https://test.pypi.org/legacy/
+
     - name: Publish distribution 📦 to PyPI
       if: github.event_name == 'release' && github.event.action == 'published' && github.repository == 'dguest/pandamonium'
       uses: pypa/gh-action-pypi-publish@v1.4.2

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -35,7 +35,7 @@ jobs:
 
     - name: Build a wheel and a sdist
       run: |
-        python -m build --sdist --wheel --outdir dist/ .
+        python -m build --outdir dist/ .
 
     - name: Verify history available for dev versions
       run: |

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -47,12 +47,12 @@ jobs:
     - name: Publish distribution 📦 to Test PyPI
       # every PR will trigger a push event on master, so check the push event is actually coming from master
       if: github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'dguest/pandamonium'
-      uses: pypa/gh-action-pypi-publish@v1.4.1
+      uses: pypa/gh-action-pypi-publish@v1.4.2
       with:
         password: ${{ secrets.test_pypi_password }}
         repository_url: https://test.pypi.org/legacy/
     - name: Publish distribution 📦 to PyPI
       if: github.event_name == 'release' && github.event.action == 'published' && github.repository == 'dguest/pandamonium'
-      uses: pypa/gh-action-pypi-publish@v1.4.1
+      uses: pypa/gh-action-pypi-publish@v1.4.2
       with:
         password: ${{ secrets.pypi_password }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,10 @@
 repos:
--   repo: https://github.com/psf/black
-    rev: 20.8b1
-    hooks:
-    - id: black
 -   repo: https://github.com/pycqa/isort
-    rev: 5.7.0
+    rev: 5.9.3
     hooks:
     - id: isort
+
+-   repo: https://github.com/psf/black
+    rev: 21.7b0
+    hooks:
+    - id: black


### PR DESCRIPTION
```
* Update pre-commit hooks and run order
   - pre-commit runs hooks sequentially, so place isort before black
* Update pypa/gh-action-pypi-publish GitHub Action to v1.4.2
* Use updated build CLI API
* Add visual check of sdist contents
```