### PR TITLE
chore: Revise MANIFEST.in strategy to properly use prune

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
+prune **
 graft src
 
 include LICENSE

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,11 @@
 prune **
 graft src
 
+include setup.py
+include setup.cfg
 include LICENSE
+include README.md
+include pyproject.toml
+include MANIFEST.in
 
 global-exclude __pycache__ *.py[cod]


### PR DESCRIPTION
c.f. https://github.com/scikit-hep/pyhf/pull/1449

```
* Use `prune **` to remove all files from the sdist
   - c.f. https://packaging.python.org/guides/using-manifest-in/#manifest-in-commands
   - "Setuptools also has undocumented support for ** matching zero or more characters including forward slash, backslash, and colon."
* Manually include all "default" files for a sdist in MANIFEST.in
   - c.f. https://packaging.python.org/guides/using-manifest-in/#how-files-are-included-in-an-sdist
```