### PR TITLE
build: Require `panda-client` `1.4.82` or later for API stability

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 79
-target-version = ['py36', 'py37', 'py38']
+target-version = ['py36', 'py37', 'py38', 'py39']
 skip-string-normalization = true
 include = '\.pyi?$'
 exclude = '''

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ packages = find:
 include_package_data = True
 python_requires = >=2.7
 install_requires =
-    panda-client>=1.0
+    panda-client>=1.4.82
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
This PR requires a minimum required version of `panda-client`  of `1.4.82` for API stability as a follow up PR to PR #58.

```
* Set lower bound on panda-client to v1.4.82 to ensure `pandaclient` API exists
   - Amends PR #58
* Add Python 3.9 to Black target-versions
```