### PR TITLE
docs: Update Matthew's affiliation to University of Wisconsin-Madison

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -11,7 +11,7 @@
             "orcid": "0000-0002-4305-2295"
         },
         {
-            "affiliation": "University of Illinois at Urbana-Champaign",
+            "affiliation": "University of Wisconsin-Madison",
             "name": "Matthew Feickert",
             "orcid": "0000-0003-4124-7862"
         }


### PR DESCRIPTION
@matthewfeickert is a postdoc at University of Wisconsin-Madison as of June 2022.