### PR TITLE
docs: Add Python 3.10 to PyPI metadata

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
 
 [bdist_wheel]
 universal = 1


### PR DESCRIPTION
As PR #66 patched a bug, it would probably be good to have a patch release, and before something goes up on PyPI it would be worthwhile to update the PyPI metadata.