### PR TITLE
Adding call to pbook additional init function

### DIFF
--- a/src/pandamonium/panda_kill_taskid.py
+++ b/src/pandamonium/panda_kill_taskid.py
@@ -40,6 +40,7 @@ def get_args():
 def kill(jobs, args):
     # enforceEnter, verbose, restoreDB
     pbook = PBookCore.PBookCore()
+    pbook.init()
 
     for job in jobs:
         pbook.kill(job)

--- a/src/pandamonium/panda_resub_taskid.py
+++ b/src/pandamonium/panda_resub_taskid.py
@@ -46,6 +46,7 @@ def get_args():
 def retry(jobs, args):
     # enforceEnter, verbose, restoreDB
     pbook = PBookCore.PBookCore()
+    pbook.init()
     retry_opts = {}
     if args.build:
         retry_opts['retryBuild'] = True


### PR DESCRIPTION
As discussed in https://github.com/dguest/pandamonium/issues/70#issuecomment-2163345574, for panda-client versions < 1.5.48, the check for proxy and extraction of username was done when you created a PBookCore object (from the initializer).  Now they default the username to None and to get it we have to call the init() function.

I tested this on top of master with command `panda-kill-taskid 39770381` (old `done` task that I had) and it worked (complained that you can't kill tasks in `done` state but that's beside the point).